### PR TITLE
GEOPY-1907: Manage name mismatch error as single line log instead of python error log.

### DIFF
--- a/geoapps_utils/__init__.py
+++ b/geoapps_utils/__init__.py
@@ -24,6 +24,7 @@ from geoapps_utils.utils import (
     transformations,
     workspace,
 )
+from geoapps_utils.utils.importing import GeoAppsError
 from geoapps_utils.utils.importing import assets_path as assets_path_impl
 
 

--- a/geoapps_utils/driver/driver.py
+++ b/geoapps_utils/driver/driver.py
@@ -117,7 +117,7 @@ class BaseDriver(ABC):
                 driver.run()
                 print(f"Results saved to {params.geoh5.h5file}")
             except GeoAppsError as error:
-                warn(f"Failed: {error}")
+                warn(f"ApplicationError: {error}")
 
         return driver
 

--- a/geoapps_utils/driver/driver.py
+++ b/geoapps_utils/driver/driver.py
@@ -16,6 +16,7 @@ from geoh5py.ui_json import InputFile, monitored_directory_copy
 
 from geoapps_utils.driver.data import BaseData
 from geoapps_utils.driver.params import BaseParams
+from geoapps_utils.utils.importing import GeoAppsError
 
 
 class BaseDriver(ABC):
@@ -111,8 +112,11 @@ class BaseDriver(ABC):
             print("Initializing application . . .")
             driver = driver_class(params)
             print("Running application . . .")
-            driver.run()
-            print(f"Results saved to {params.geoh5.h5file}")
+            try:
+                driver.run()
+                print(f"Results saved to {params.geoh5.h5file}")
+            except GeoAppsError as error:
+                print(f"Error: {error}")
 
         return driver
 

--- a/geoapps_utils/driver/driver.py
+++ b/geoapps_utils/driver/driver.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
+from warnings import warn
 
 from geoh5py import Workspace
 from geoh5py.objects import ObjectBase
@@ -116,7 +117,7 @@ class BaseDriver(ABC):
                 driver.run()
                 print(f"Results saved to {params.geoh5.h5file}")
             except GeoAppsError as error:
-                print(f"Error: {error}")
+                warn(f"Failed: {error}")
 
         return driver
 

--- a/geoapps_utils/utils/importing.py
+++ b/geoapps_utils/utils/importing.py
@@ -71,3 +71,9 @@ def assets_path(module_path: Path | str) -> Path:
         raise RuntimeError(f"Assets folder not found: {assets_folder}")
 
     return assets_folder
+
+
+class GeoAppsError(Exception):
+    """
+    Base class for exceptions in this module.
+    """


### PR DESCRIPTION
**GEOPY-1907 - Manage name mismatch error as single line log instead of python error log.**
Create a custom error to catch in start