### PR TITLE
GEOPY-1907: Manage name mismatch error as single line log instead of python error log.

### DIFF
--- a/geoapps_utils/driver/driver.py
+++ b/geoapps_utils/driver/driver.py
@@ -117,7 +117,7 @@ class BaseDriver(ABC):
                 driver.run()
                 print(f"Results saved to {params.geoh5.h5file}")
             except GeoAppsError as error:
-                warn(f"ApplicationError: {error}")
+                warn(f"\n\nApplicationError: {error}\n\n")
 
         return driver
 


### PR DESCRIPTION
**GEOPY-1907 - Manage name mismatch error as single line log instead of python error log.**
add skip line to make the error more obvious.