### PR TITLE
GEOPY-1862: for pypi, use dedicated package.rst as long description (readme field) instead of README.rst

### DIFF
--- a/package.rst
+++ b/package.rst
@@ -29,7 +29,7 @@ License
 ^^^^^^^
 MIT License
 
-Copyright (c) 2020-2025 Mira Geoscience
+Copyright (c) 2022-2025 Mira Geoscience
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -58,7 +58,3 @@ Third Party Software notices and/or additional terms and conditions are located 
 `THIRD_PARTY_SOFTWARE.rst`_ file.
 
 .. _THIRD_PARTY_SOFTWARE.rst: THIRD_PARTY_SOFTWARE.rst
-
-Copyright
-^^^^^^^^^
-Copyright (c) 2024-2025 Mira Geoscience Ltd.

--- a/package.rst
+++ b/package.rst
@@ -1,0 +1,64 @@
+geoapps-utils
+=============
+
+The **geoapps-utils** package provides utility functions
+used by Python applications supported by `Mira Geoscience <https://www.mirageoscience.com/mining-industry-software/geoscience-analyst/python-integration/>`_
+
+Installation
+^^^^^^^^^^^^
+**geoapps-utils** is currently written for Python 3.10 or higher.
+
+Install **geoapps-utils** from PyPI::
+
+    $ pip install geoapps-utils
+
+
+Feedback
+^^^^^^^^
+Have comments or suggestions? Submit feedback.
+All the content can be found on the github_ repository.
+
+.. _github: https://github.com/MiraGeoscience/geoapps-utils
+
+
+Visit `Mira Geoscience website <https://mirageoscience.com/>`_ to learn more about our products
+and services.
+
+
+License
+^^^^^^^
+MIT License
+
+Copyright (c) 2020-2025 Mira Geoscience
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Third Party Software
+^^^^^^^^^^^^^^^^^^^^
+The geoapps-utils Software may provide links to third party libraries or code (collectively “Third Party Software”)
+to implement various functions. Third Party Software does not comprise part of the Software.
+The use of Third Party Software is governed by the terms of such software license(s).
+Third Party Software notices and/or additional terms and conditions are located in the
+`THIRD_PARTY_SOFTWARE.rst`_ file.
+
+.. _THIRD_PARTY_SOFTWARE.rst: THIRD_PARTY_SOFTWARE.rst
+
+Copyright
+^^^^^^^^^
+Copyright (c) 2024-2025 Mira Geoscience Ltd.


### PR DESCRIPTION
**GEOPY-1862 - for pypi, use dedicated package.rst as long description (readme field) instead of README.rst**
