### PR TITLE
GEOPY-2376: Investigate double-print of of Geoapps-Error

### DIFF
--- a/geoapps_utils/base.py
+++ b/geoapps_utils/base.py
@@ -30,7 +30,7 @@ from geoapps_utils.utils.importing import GeoAppsError
 from geoapps_utils.utils.logger import get_logger
 
 
-logger = get_logger(name=__name__)
+logger = get_logger(name=__name__, level_name=False, propagate=False, add_name=False)
 
 
 class Driver(ABC):

--- a/geoapps_utils/utils/logger.py
+++ b/geoapps_utils/utils/logger.py
@@ -16,6 +16,8 @@ def get_logger(
     name: str | None = None,
     timestamp: bool = False,
     level_name: bool = True,
+    propagate: bool = True,
+    add_name: bool = True,
 ) -> logging.Logger:
     """
     Get a logger with a timestamped stream and specified log level.
@@ -23,6 +25,8 @@ def get_logger(
     :param name: Name of the logger.
     :param timestamp: Whether to include a timestamp in the log format.
     :param level_name: Whether to include the log level name in the log format.
+    :param propagate: Whether to propagate log messages to the parent logger.
+    :param add_name: Whether to include the logger name in the log format.
 
     :return: Configured logger instance.
     """
@@ -38,7 +42,7 @@ def get_logger(
     if level_name:
         formatting = "%(levelname)s "
 
-    if name:
+    if name and add_name:
         formatting += "[%(name)s] "
 
     if timestamp:
@@ -47,5 +51,6 @@ def get_logger(
     formatter = logging.Formatter(formatting + "%(message)s")
     stream_handler.setFormatter(formatter)
     log.addHandler(stream_handler)
+    log.propagate = propagate
 
     return log


### PR DESCRIPTION
**GEOPY-2376 - Investigate double-print of of Geoapps-Error**
improve fonction to not:

-propagate the logger
-print the name at the beginning

add those options to False in Base as it's ugly and useless