### PR TITLE
DEVOPS-693: relock conda envs

### DIFF
--- a/environments/py-3.10-linux-64-dev.conda.lock.yml
+++ b/environments/py-3.10-linux-64-dev.conda.lock.yml
@@ -9,18 +9,18 @@ dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
   - annotated-types=0.7.0=pyhd8ed1ab_1
-  - astroid=3.3.11=py310hff52083_0
+  - astroid=3.3.11=py310hff52083_1
   - bzip2=1.0.8=h4bc722e_7
   - c-ares=1.34.5=hb9d3cd8_0
   - ca-certificates=2025.8.3=hbd8a1cb_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - colorama=0.4.6=pyhd8ed1ab_1
-  - coverage=7.10.5=py310h3406613_0
+  - coverage=7.10.6=py310h3406613_0
   - dill=0.4.0=pyhd8ed1ab_0
   - exceptiongroup=1.3.0=pyhd8ed1ab_0
   - freetype=2.13.3=ha770c72_1
-  - h5py=3.14.0=nompi_py310hea1e86d_100
+  - h5py=3.14.0=nompi_py310h4aa865e_101
   - hdf5=1.14.6=nompi_h6e4c0c1_103
   - iniconfig=2.0.0=pyhd8ed1ab_1
   - isort=6.0.1=pyhd8ed1ab_1
@@ -49,7 +49,7 @@ dependencies:
   - libjpeg-turbo=3.1.0=hb9d3cd8_0
   - liblapack=3.9.0=34_h7ac8fdf_openblas
   - liblzma=5.8.1=hb9d3cd8_2
-  - libnghttp2=1.64.0=h161d5f1_0
+  - libnghttp2=1.67.0=had1ee68_0
   - libnsl=2.0.1=hb9d3cd8_1
   - libopenblas=0.3.30=pthreads_h94d23a6_2
   - libpng=1.6.50=h421ea60_1
@@ -101,7 +101,7 @@ dependencies:
   - yaml=0.2.5=h280c20c_3
   - zstd=1.5.7=hb8e6e7a_2
   - pip:
-    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.10-linux-64.conda.lock.yml
+++ b/environments/py-3.10-linux-64.conda.lock.yml
@@ -15,7 +15,7 @@ dependencies:
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - freetype=2.13.3=ha770c72_1
-  - h5py=3.14.0=nompi_py310hea1e86d_100
+  - h5py=3.14.0=nompi_py310h4aa865e_101
   - hdf5=1.14.6=nompi_h6e4c0c1_103
   - keyutils=1.6.3=hb9d3cd8_0
   - krb5=1.21.3=h659f571_0
@@ -41,7 +41,7 @@ dependencies:
   - libjpeg-turbo=3.1.0=hb9d3cd8_0
   - liblapack=3.9.0=34_h7ac8fdf_openblas
   - liblzma=5.8.1=hb9d3cd8_2
-  - libnghttp2=1.64.0=h161d5f1_0
+  - libnghttp2=1.67.0=had1ee68_0
   - libnsl=2.0.1=hb9d3cd8_1
   - libopenblas=0.3.30=pthreads_h94d23a6_2
   - libpng=1.6.50=h421ea60_1
@@ -79,7 +79,7 @@ dependencies:
   - xorg-libxdmcp=1.1.5=hb9d3cd8_0
   - zstd=1.5.7=hb8e6e7a_2
   - pip:
-    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.10-win-64-dev.conda.lock.yml
+++ b/environments/py-3.10-win-64-dev.conda.lock.yml
@@ -8,17 +8,17 @@ channels:
 dependencies:
   - _openmp_mutex=4.5=2_gnu
   - annotated-types=0.7.0=pyhd8ed1ab_1
-  - astroid=3.3.11=py310h5588dad_0
+  - astroid=3.3.11=py310h5588dad_1
   - bzip2=1.0.8=h2466b09_7
   - ca-certificates=2025.8.3=h4c7d964_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - colorama=0.4.6=pyhd8ed1ab_1
-  - coverage=7.10.5=py310hdb0e946_0
+  - coverage=7.10.6=py310hdb0e946_0
   - dill=0.4.0=pyhd8ed1ab_0
   - exceptiongroup=1.3.0=pyhd8ed1ab_0
   - freetype=2.13.3=h57928b3_1
-  - h5py=3.14.0=nompi_py310h877c39c_100
+  - h5py=3.14.0=nompi_py310hb7e4da9_101
   - hdf5=1.14.6=nompi_he30205f_103
   - iniconfig=2.0.0=pyhd8ed1ab_1
   - isort=6.0.1=pyhd8ed1ab_1
@@ -84,7 +84,7 @@ dependencies:
   - typing-inspection=0.4.1=pyhd8ed1ab_0
   - typing_extensions=4.15.0=pyhcf101f3_0
   - tzdata=2025b=h78e105d_0
-  - ucrt=10.0.22621.0=h57928b3_1
+  - ucrt=10.0.26100.0=h57928b3_0
   - vc=14.3=h41ae7f8_31
   - vc14_runtime=14.44.35208=h818238b_31
   - vcomp14=14.44.35208=h818238b_31
@@ -94,7 +94,7 @@ dependencies:
   - yaml=0.2.5=h6a83c73_3
   - zstd=1.5.7=hbeecb71_2
   - pip:
-    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.10-win-64.conda.lock.yml
+++ b/environments/py-3.10-win-64.conda.lock.yml
@@ -13,7 +13,7 @@ dependencies:
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - freetype=2.13.3=h57928b3_1
-  - h5py=3.14.0=nompi_py310h877c39c_100
+  - h5py=3.14.0=nompi_py310hb7e4da9_101
   - hdf5=1.14.6=nompi_he30205f_103
   - krb5=1.21.3=hdf4eb48_0
   - lcms2=2.17=hbcf6048_0
@@ -63,7 +63,7 @@ dependencies:
   - typing-inspection=0.4.1=pyhd8ed1ab_0
   - typing_extensions=4.15.0=pyhcf101f3_0
   - tzdata=2025b=h78e105d_0
-  - ucrt=10.0.22621.0=h57928b3_1
+  - ucrt=10.0.26100.0=h57928b3_0
   - vc=14.3=h41ae7f8_31
   - vc14_runtime=14.44.35208=h818238b_31
   - vcomp14=14.44.35208=h818238b_31
@@ -72,7 +72,7 @@ dependencies:
   - xorg-libxdmcp=1.1.5=h0e40799_0
   - zstd=1.5.7=hbeecb71_2
   - pip:
-    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.11-linux-64-dev.conda.lock.yml
+++ b/environments/py-3.11-linux-64-dev.conda.lock.yml
@@ -9,18 +9,18 @@ dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
   - annotated-types=0.7.0=pyhd8ed1ab_1
-  - astroid=3.3.11=py311h38be061_0
+  - astroid=3.3.11=py311h38be061_1
   - bzip2=1.0.8=h4bc722e_7
   - c-ares=1.34.5=hb9d3cd8_0
   - ca-certificates=2025.8.3=hbd8a1cb_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - colorama=0.4.6=pyhd8ed1ab_1
-  - coverage=7.10.5=py311h3778330_0
+  - coverage=7.10.6=py311h3778330_0
   - dill=0.4.0=pyhd8ed1ab_0
   - exceptiongroup=1.3.0=pyhd8ed1ab_0
   - freetype=2.13.3=ha770c72_1
-  - h5py=3.14.0=nompi_py311h7f87ba5_100
+  - h5py=3.14.0=nompi_py311h0b2f468_101
   - hdf5=1.14.6=nompi_h6e4c0c1_103
   - iniconfig=2.0.0=pyhd8ed1ab_1
   - isort=6.0.1=pyhd8ed1ab_1
@@ -49,7 +49,7 @@ dependencies:
   - libjpeg-turbo=3.1.0=hb9d3cd8_0
   - liblapack=3.9.0=34_h7ac8fdf_openblas
   - liblzma=5.8.1=hb9d3cd8_2
-  - libnghttp2=1.64.0=h161d5f1_0
+  - libnghttp2=1.67.0=had1ee68_0
   - libnsl=2.0.1=hb9d3cd8_1
   - libopenblas=0.3.30=pthreads_h94d23a6_2
   - libpng=1.6.50=h421ea60_1
@@ -101,7 +101,7 @@ dependencies:
   - yaml=0.2.5=h280c20c_3
   - zstd=1.5.7=hb8e6e7a_2
   - pip:
-    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.11-linux-64.conda.lock.yml
+++ b/environments/py-3.11-linux-64.conda.lock.yml
@@ -15,7 +15,7 @@ dependencies:
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - freetype=2.13.3=ha770c72_1
-  - h5py=3.14.0=nompi_py311h7f87ba5_100
+  - h5py=3.14.0=nompi_py311h0b2f468_101
   - hdf5=1.14.6=nompi_h6e4c0c1_103
   - keyutils=1.6.3=hb9d3cd8_0
   - krb5=1.21.3=h659f571_0
@@ -41,7 +41,7 @@ dependencies:
   - libjpeg-turbo=3.1.0=hb9d3cd8_0
   - liblapack=3.9.0=34_h7ac8fdf_openblas
   - liblzma=5.8.1=hb9d3cd8_2
-  - libnghttp2=1.64.0=h161d5f1_0
+  - libnghttp2=1.67.0=had1ee68_0
   - libnsl=2.0.1=hb9d3cd8_1
   - libopenblas=0.3.30=pthreads_h94d23a6_2
   - libpng=1.6.50=h421ea60_1
@@ -79,7 +79,7 @@ dependencies:
   - xorg-libxdmcp=1.1.5=hb9d3cd8_0
   - zstd=1.5.7=hb8e6e7a_2
   - pip:
-    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.11-win-64-dev.conda.lock.yml
+++ b/environments/py-3.11-win-64-dev.conda.lock.yml
@@ -8,17 +8,17 @@ channels:
 dependencies:
   - _openmp_mutex=4.5=2_gnu
   - annotated-types=0.7.0=pyhd8ed1ab_1
-  - astroid=3.3.11=py311h1ea47a8_0
+  - astroid=3.3.11=py311h1ea47a8_1
   - bzip2=1.0.8=h2466b09_7
   - ca-certificates=2025.8.3=h4c7d964_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - colorama=0.4.6=pyhd8ed1ab_1
-  - coverage=7.10.5=py311h3f79411_0
+  - coverage=7.10.6=py311h3f79411_0
   - dill=0.4.0=pyhd8ed1ab_0
   - exceptiongroup=1.3.0=pyhd8ed1ab_0
   - freetype=2.13.3=h57928b3_1
-  - h5py=3.14.0=nompi_py311h97e6cc2_100
+  - h5py=3.14.0=nompi_py311hc40ba4b_101
   - hdf5=1.14.6=nompi_he30205f_103
   - iniconfig=2.0.0=pyhd8ed1ab_1
   - isort=6.0.1=pyhd8ed1ab_1
@@ -84,7 +84,7 @@ dependencies:
   - typing-inspection=0.4.1=pyhd8ed1ab_0
   - typing_extensions=4.15.0=pyhcf101f3_0
   - tzdata=2025b=h78e105d_0
-  - ucrt=10.0.22621.0=h57928b3_1
+  - ucrt=10.0.26100.0=h57928b3_0
   - vc=14.3=h41ae7f8_31
   - vc14_runtime=14.44.35208=h818238b_31
   - vcomp14=14.44.35208=h818238b_31
@@ -94,7 +94,7 @@ dependencies:
   - yaml=0.2.5=h6a83c73_3
   - zstd=1.5.7=hbeecb71_2
   - pip:
-    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.11-win-64.conda.lock.yml
+++ b/environments/py-3.11-win-64.conda.lock.yml
@@ -13,7 +13,7 @@ dependencies:
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - freetype=2.13.3=h57928b3_1
-  - h5py=3.14.0=nompi_py311h97e6cc2_100
+  - h5py=3.14.0=nompi_py311hc40ba4b_101
   - hdf5=1.14.6=nompi_he30205f_103
   - krb5=1.21.3=hdf4eb48_0
   - lcms2=2.17=hbcf6048_0
@@ -63,7 +63,7 @@ dependencies:
   - typing-inspection=0.4.1=pyhd8ed1ab_0
   - typing_extensions=4.15.0=pyhcf101f3_0
   - tzdata=2025b=h78e105d_0
-  - ucrt=10.0.22621.0=h57928b3_1
+  - ucrt=10.0.26100.0=h57928b3_0
   - vc=14.3=h41ae7f8_31
   - vc14_runtime=14.44.35208=h818238b_31
   - vcomp14=14.44.35208=h818238b_31
@@ -72,7 +72,7 @@ dependencies:
   - xorg-libxdmcp=1.1.5=h0e40799_0
   - zstd=1.5.7=hbeecb71_2
   - pip:
-    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.12-linux-64-dev.conda.lock.yml
+++ b/environments/py-3.12-linux-64-dev.conda.lock.yml
@@ -9,18 +9,18 @@ dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
   - annotated-types=0.7.0=pyhd8ed1ab_1
-  - astroid=3.3.11=py312h7900ff3_0
+  - astroid=3.3.11=py312h7900ff3_1
   - bzip2=1.0.8=h4bc722e_7
   - c-ares=1.34.5=hb9d3cd8_0
   - ca-certificates=2025.8.3=hbd8a1cb_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - colorama=0.4.6=pyhd8ed1ab_1
-  - coverage=7.10.5=py312h8a5da7c_0
+  - coverage=7.10.6=py312h8a5da7c_0
   - dill=0.4.0=pyhd8ed1ab_0
   - exceptiongroup=1.3.0=pyhd8ed1ab_0
   - freetype=2.13.3=ha770c72_1
-  - h5py=3.14.0=nompi_py312h3faca00_100
+  - h5py=3.14.0=nompi_py312ha4f8f14_101
   - hdf5=1.14.6=nompi_h6e4c0c1_103
   - iniconfig=2.0.0=pyhd8ed1ab_1
   - isort=6.0.1=pyhd8ed1ab_1
@@ -49,7 +49,7 @@ dependencies:
   - libjpeg-turbo=3.1.0=hb9d3cd8_0
   - liblapack=3.9.0=34_h7ac8fdf_openblas
   - liblzma=5.8.1=hb9d3cd8_2
-  - libnghttp2=1.64.0=h161d5f1_0
+  - libnghttp2=1.67.0=had1ee68_0
   - libnsl=2.0.1=hb9d3cd8_1
   - libopenblas=0.3.30=pthreads_h94d23a6_2
   - libpng=1.6.50=h421ea60_1
@@ -101,7 +101,7 @@ dependencies:
   - yaml=0.2.5=h280c20c_3
   - zstd=1.5.7=hb8e6e7a_2
   - pip:
-    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.12-linux-64.conda.lock.yml
+++ b/environments/py-3.12-linux-64.conda.lock.yml
@@ -15,7 +15,7 @@ dependencies:
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - freetype=2.13.3=ha770c72_1
-  - h5py=3.14.0=nompi_py312h3faca00_100
+  - h5py=3.14.0=nompi_py312ha4f8f14_101
   - hdf5=1.14.6=nompi_h6e4c0c1_103
   - keyutils=1.6.3=hb9d3cd8_0
   - krb5=1.21.3=h659f571_0
@@ -41,7 +41,7 @@ dependencies:
   - libjpeg-turbo=3.1.0=hb9d3cd8_0
   - liblapack=3.9.0=34_h7ac8fdf_openblas
   - liblzma=5.8.1=hb9d3cd8_2
-  - libnghttp2=1.64.0=h161d5f1_0
+  - libnghttp2=1.67.0=had1ee68_0
   - libnsl=2.0.1=hb9d3cd8_1
   - libopenblas=0.3.30=pthreads_h94d23a6_2
   - libpng=1.6.50=h421ea60_1
@@ -79,7 +79,7 @@ dependencies:
   - xorg-libxdmcp=1.1.5=hb9d3cd8_0
   - zstd=1.5.7=hb8e6e7a_2
   - pip:
-    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.12-win-64-dev.conda.lock.yml
+++ b/environments/py-3.12-win-64-dev.conda.lock.yml
@@ -8,17 +8,17 @@ channels:
 dependencies:
   - _openmp_mutex=4.5=2_gnu
   - annotated-types=0.7.0=pyhd8ed1ab_1
-  - astroid=3.3.11=py312h2e8e312_0
+  - astroid=3.3.11=py312h2e8e312_1
   - bzip2=1.0.8=h2466b09_7
   - ca-certificates=2025.8.3=h4c7d964_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - colorama=0.4.6=pyhd8ed1ab_1
-  - coverage=7.10.5=py312h05f76fc_0
+  - coverage=7.10.6=py312h05f76fc_0
   - dill=0.4.0=pyhd8ed1ab_0
   - exceptiongroup=1.3.0=pyhd8ed1ab_0
   - freetype=2.13.3=h57928b3_1
-  - h5py=3.14.0=nompi_py312h6cc2a29_100
+  - h5py=3.14.0=nompi_py312h03cd2ba_101
   - hdf5=1.14.6=nompi_he30205f_103
   - iniconfig=2.0.0=pyhd8ed1ab_1
   - isort=6.0.1=pyhd8ed1ab_1
@@ -84,7 +84,7 @@ dependencies:
   - typing-inspection=0.4.1=pyhd8ed1ab_0
   - typing_extensions=4.15.0=pyhcf101f3_0
   - tzdata=2025b=h78e105d_0
-  - ucrt=10.0.22621.0=h57928b3_1
+  - ucrt=10.0.26100.0=h57928b3_0
   - vc=14.3=h41ae7f8_31
   - vc14_runtime=14.44.35208=h818238b_31
   - vcomp14=14.44.35208=h818238b_31
@@ -94,7 +94,7 @@ dependencies:
   - yaml=0.2.5=h6a83c73_3
   - zstd=1.5.7=hbeecb71_2
   - pip:
-    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
 
 variables:
   KMP_WARNINGS: 0

--- a/environments/py-3.12-win-64.conda.lock.yml
+++ b/environments/py-3.12-win-64.conda.lock.yml
@@ -13,7 +13,7 @@ dependencies:
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - freetype=2.13.3=h57928b3_1
-  - h5py=3.14.0=nompi_py312h6cc2a29_100
+  - h5py=3.14.0=nompi_py312h03cd2ba_101
   - hdf5=1.14.6=nompi_he30205f_103
   - krb5=1.21.3=hdf4eb48_0
   - lcms2=2.17=hbcf6048_0
@@ -63,7 +63,7 @@ dependencies:
   - typing-inspection=0.4.1=pyhd8ed1ab_0
   - typing_extensions=4.15.0=pyhcf101f3_0
   - tzdata=2025b=h78e105d_0
-  - ucrt=10.0.22621.0=h57928b3_1
+  - ucrt=10.0.26100.0=h57928b3_0
   - vc=14.3=h41ae7f8_31
   - vc14_runtime=14.44.35208=h818238b_31
   - vcomp14=14.44.35208=h818238b_31
@@ -72,7 +72,7 @@ dependencies:
   - xorg-libxdmcp=1.1.5=h0e40799_0
   - zstd=1.5.7=hbeecb71_2
   - pip:
-    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    - geoh5py @ git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
 
 variables:
   KMP_WARNINGS: 0

--- a/py-3.10.conda-lock.yml
+++ b/py-3.10.conda-lock.yml
@@ -100,10 +100,10 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     typing_extensions: '>=4'
-  url: https://repo.prefix.dev/conda-forge/linux-64/astroid-3.3.11-py310hff52083_0.conda
+  url: https://repo.prefix.dev/conda-forge/linux-64/astroid-3.3.11-py310hff52083_1.conda
   hash:
-    md5: a6ac735bba663f77669789c9ed1d4bd1
-    sha256: 7546e57aceee80ff58388c6cfcc072f8c0df057a87bed551325a404b13b9012d
+    md5: cf84a0665b3e7ec2056ae606b4ce1378
+    sha256: 223f1330a5ddb1b3b28be57f966c04603902e0bb7b22dbb4a29f1d1240ec1ed7
   category: dev
   optional: true
 - name: astroid
@@ -114,10 +114,10 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     typing_extensions: '>=4'
-  url: https://repo.prefix.dev/conda-forge/win-64/astroid-3.3.11-py310h5588dad_0.conda
+  url: https://repo.prefix.dev/conda-forge/win-64/astroid-3.3.11-py310h5588dad_1.conda
   hash:
-    md5: 6f5ec356c2f46223dc446283fd39acb7
-    sha256: 2f4d34b9b4fb7c3902ba1f63e4d43625084a544993a7f14fac8403fbc1376246
+    md5: 6cd63bf117fad2a1359e93bdaab4884f
+    sha256: 1daca67f30e02b3d1116aa512ac263e7c8ace9bba77341fb3eff7d3a930197a6
   category: dev
   optional: true
 - name: bzip2
@@ -257,7 +257,7 @@ package:
   category: dev
   optional: true
 - name: coverage
-  version: 7.10.5
+  version: 7.10.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -266,14 +266,14 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     tomli: ''
-  url: https://repo.prefix.dev/conda-forge/linux-64/coverage-7.10.5-py310h3406613_0.conda
+  url: https://repo.prefix.dev/conda-forge/linux-64/coverage-7.10.6-py310h3406613_0.conda
   hash:
-    md5: 8d397b33a3a90f52182807e04234ea10
-    sha256: 1cfe98f11884062729c9b861ed3d4e9c771f6809d8fed8be68d8c585216fa147
+    md5: 0556c27c1bd399aa6e54e1d1ae15da4f
+    sha256: b1687146a27cbf11703857f5b1c7f557536adf128f5391e3149f10b6391790b7
   category: dev
   optional: true
 - name: coverage
-  version: 7.10.5
+  version: 7.10.6
   manager: conda
   platform: win-64
   dependencies:
@@ -283,10 +283,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://repo.prefix.dev/conda-forge/win-64/coverage-7.10.5-py310hdb0e946_0.conda
+  url: https://repo.prefix.dev/conda-forge/win-64/coverage-7.10.6-py310hdb0e946_0.conda
   hash:
-    md5: df429c46178f2ac242180da4c4d2c821
-    sha256: eb6013687b9940940d3b3292d14b77266bf5551de09cd8f32e4cf7ccf555c0e4
+    md5: 8dacce8ea330a59cd5f521ab8fb0ba8f
+    sha256: b53ba6cda0a3c61a58d156bd1e647e95413b984f6a391a60395391951bc41d15
   category: dev
   optional: true
 - name: dill
@@ -373,14 +373,14 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     cached-property: ''
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    libgcc: '>=13'
+    libgcc: '>=14'
     numpy: '>=1.21,<3'
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
-  url: https://repo.prefix.dev/conda-forge/linux-64/h5py-3.14.0-nompi_py310hea1e86d_100.conda
+  url: https://repo.prefix.dev/conda-forge/linux-64/h5py-3.14.0-nompi_py310h4aa865e_101.conda
   hash:
-    md5: f6879e3fc12006cffde701eb08ce1f09
-    sha256: 8c7d6fea5345596f1fbef21b99fbc04cef6e7cfa5023619232da52fab80b554f
+    md5: 67774c5937389b35e4efd43d7baa923e
+    sha256: 68641d6f5c5c2a916437b67008fab342b599b6dfd711a0f43c00db5c72412d26
   category: main
   optional: false
 - name: h5py
@@ -394,12 +394,12 @@ package:
     python: '>=3.10,<3.11.0a0'
     python_abi: 3.10.*
     ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://repo.prefix.dev/conda-forge/win-64/h5py-3.14.0-nompi_py310h877c39c_100.conda
+    vc: '>=14.3,<15'
+    vc14_runtime: '>=14.44.35208'
+  url: https://repo.prefix.dev/conda-forge/win-64/h5py-3.14.0-nompi_py310hb7e4da9_101.conda
   hash:
-    md5: 5b861086c5a7689a6d95c4df10d211e4
-    sha256: 754155af401cb3577c3e76ed7a4427ad9928c210d32b8571f84492c54b67f5a4
+    md5: 2e924eca630566b4b0f51a98a232122e
+    sha256: 66d2c79028f031326139dfb31e4e8af9acde01da3ac89551e7d50cbf29b6cb8f
   category: main
   optional: false
 - name: hdf5
@@ -1099,21 +1099,21 @@ package:
   category: main
   optional: false
 - name: libnghttp2
-  version: 1.64.0
+  version: 1.67.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.32.3,<2.0a0'
+    c-ares: '>=1.34.5,<2.0a0'
     libev: '>=4.33,<5.0a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://repo.prefix.dev/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+    openssl: '>=3.5.2,<4.0a0'
+  url: https://repo.prefix.dev/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
   hash:
-    md5: 19e57602824042dfd0446292ef90488b
-    sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+    md5: b499ce4b026493a13774bcf0f4c33849
+    sha256: a4a7dab8db4dc81c736e9a9b42bdfd97b087816e029e221380511960ac46c690
   category: main
   optional: false
 - name: libnsl
@@ -2407,14 +2407,14 @@ package:
   category: main
   optional: false
 - name: ucrt
-  version: 10.0.22621.0
+  version: 10.0.26100.0
   manager: conda
   platform: win-64
   dependencies: {}
-  url: https://repo.prefix.dev/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  url: https://repo.prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
   hash:
-    md5: 6797b005cd0f439c4c5c9ac565783700
-    sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+    md5: 71b24316859acd00bdb8b38f5e2ce328
+    sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
   category: main
   optional: false
 - name: vc
@@ -2590,7 +2590,7 @@ package:
   category: main
   optional: false
 - name: geoh5py
-  version: 0.12.0a2.dev42+ae647668
+  version: 0.12.0a2.dev60+3a91dd92
   manager: pip
   platform: linux-64
   dependencies:
@@ -2598,16 +2598,16 @@ package:
     numpy: '>=1.26.0,<1.27.0'
     pillow: '>=10.3.0,<10.4.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
   hash:
-    sha256: ae6476684d48892a7ce863c1165b8f6f488a3867
+    sha256: 3a91dd92144a34b3c1ad1e5885029a7102e6337c
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
   category: main
   optional: false
 - name: geoh5py
-  version: 0.12.0a2.dev42+ae647668
+  version: 0.12.0a2.dev60+3a91dd92
   manager: pip
   platform: win-64
   dependencies:
@@ -2615,11 +2615,11 @@ package:
     numpy: '>=1.26.0,<1.27.0'
     pillow: '>=10.3.0,<10.4.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
   hash:
-    sha256: ae6476684d48892a7ce863c1165b8f6f488a3867
+    sha256: 3a91dd92144a34b3c1ad1e5885029a7102e6337c
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
   category: main
   optional: false

--- a/py-3.11.conda-lock.yml
+++ b/py-3.11.conda-lock.yml
@@ -99,10 +99,10 @@ package:
   dependencies:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://repo.prefix.dev/conda-forge/linux-64/astroid-3.3.11-py311h38be061_0.conda
+  url: https://repo.prefix.dev/conda-forge/linux-64/astroid-3.3.11-py311h38be061_1.conda
   hash:
-    md5: 5b60818e202c1b50da4e4fb9c84fe7b4
-    sha256: d0b2c99d3cc091f11c46dae464fb319a7c59d02dbca5423d99d2fa3aba8f4622
+    md5: 773635d5d5594beb7fc47054cea6a741
+    sha256: 7473a0c0f53ed38f60cf0bb39b744b4cd88d3bce88dc7487d69f45cffcdaf9f6
   category: dev
   optional: true
 - name: astroid
@@ -112,10 +112,10 @@ package:
   dependencies:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://repo.prefix.dev/conda-forge/win-64/astroid-3.3.11-py311h1ea47a8_0.conda
+  url: https://repo.prefix.dev/conda-forge/win-64/astroid-3.3.11-py311h1ea47a8_1.conda
   hash:
-    md5: c5753dd2c7c94426f58d4211fa11f0dd
-    sha256: 45e56ffb92124c4c08843fb2219888248dc483fdb408c80b4d6844ff1135a4e8
+    md5: 4cccc0a3742da6ea198a61ec6b12b6b5
+    sha256: a5e8694589a10137416ef44609de13022042a840996387faf10b32abf2b0f9fb
   category: dev
   optional: true
 - name: bzip2
@@ -255,7 +255,7 @@ package:
   category: dev
   optional: true
 - name: coverage
-  version: 7.10.5
+  version: 7.10.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -264,14 +264,14 @@ package:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     tomli: ''
-  url: https://repo.prefix.dev/conda-forge/linux-64/coverage-7.10.5-py311h3778330_0.conda
+  url: https://repo.prefix.dev/conda-forge/linux-64/coverage-7.10.6-py311h3778330_0.conda
   hash:
-    md5: f2d902e3e28e59a8a281b84ba7c74419
-    sha256: bcd74f7a948bd189aa4517e3e03520adfa020bdcb91ef63e418cddbc45c162c7
+    md5: e9cbe50bfe64007c7943ec3e349327e9
+    sha256: 260a003be89c82074188980fdfd8e124fc0209c29d1ab9a92a1dc8d2fa240c16
   category: dev
   optional: true
 - name: coverage
-  version: 7.10.5
+  version: 7.10.6
   manager: conda
   platform: win-64
   dependencies:
@@ -281,10 +281,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://repo.prefix.dev/conda-forge/win-64/coverage-7.10.5-py311h3f79411_0.conda
+  url: https://repo.prefix.dev/conda-forge/win-64/coverage-7.10.6-py311h3f79411_0.conda
   hash:
-    md5: 44ebd376a0e3d335cec3ab9c26812d6b
-    sha256: 49c695a9ded7d1bc73c4d6c2924cd9a9d7333c3f2e9df4ab738f6f7545573e14
+    md5: 77e0672d8ff3b157513528829d0c9be0
+    sha256: 22fd895a2acc48ba974782816172c26220c9dfef697cdf86546fc32f8d213a5b
   category: dev
   optional: true
 - name: dill
@@ -371,14 +371,14 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     cached-property: ''
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    libgcc: '>=13'
-    numpy: '>=1.21,<3'
+    libgcc: '>=14'
+    numpy: '>=1.23,<3'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
-  url: https://repo.prefix.dev/conda-forge/linux-64/h5py-3.14.0-nompi_py311h7f87ba5_100.conda
+  url: https://repo.prefix.dev/conda-forge/linux-64/h5py-3.14.0-nompi_py311h0b2f468_101.conda
   hash:
-    md5: ecfcdeb88c8727f3cf67e1177528a498
-    sha256: cd2bd076c9d9bd8d8021698159e694a8600d8349e3208719c422af2c86b9c184
+    md5: b3dd5deacc3147498b31366315fdc6cc
+    sha256: f5d1955b90eb7060ee6f81bc39de0f4f8e28247b8fe810d70382b4fde9e0e1f9
   category: main
   optional: false
 - name: h5py
@@ -388,16 +388,16 @@ package:
   dependencies:
     cached-property: ''
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    numpy: '>=1.21,<3'
+    numpy: '>=1.23,<3'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.*
     ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://repo.prefix.dev/conda-forge/win-64/h5py-3.14.0-nompi_py311h97e6cc2_100.conda
+    vc: '>=14.3,<15'
+    vc14_runtime: '>=14.44.35208'
+  url: https://repo.prefix.dev/conda-forge/win-64/h5py-3.14.0-nompi_py311hc40ba4b_101.conda
   hash:
-    md5: f806b981514c8d3e567a2b7d5a8569ff
-    sha256: 600c7089e5fd40d9592d2d881192052b8c6df5f3afe9cd5e51fb8ef2bc8df1bc
+    md5: 2ffcf6af42f0eadff1fa73417b848096
+    sha256: 34aae9b53e14cf62373a5bd1f475151430e4257cad6626a5d38469367b049da3
   category: main
   optional: false
 - name: hdf5
@@ -1097,21 +1097,21 @@ package:
   category: main
   optional: false
 - name: libnghttp2
-  version: 1.64.0
+  version: 1.67.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.32.3,<2.0a0'
+    c-ares: '>=1.34.5,<2.0a0'
     libev: '>=4.33,<5.0a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://repo.prefix.dev/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+    openssl: '>=3.5.2,<4.0a0'
+  url: https://repo.prefix.dev/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
   hash:
-    md5: 19e57602824042dfd0446292ef90488b
-    sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+    md5: b499ce4b026493a13774bcf0f4c33849
+    sha256: a4a7dab8db4dc81c736e9a9b42bdfd97b087816e029e221380511960ac46c690
   category: main
   optional: false
 - name: libnsl
@@ -2405,14 +2405,14 @@ package:
   category: main
   optional: false
 - name: ucrt
-  version: 10.0.22621.0
+  version: 10.0.26100.0
   manager: conda
   platform: win-64
   dependencies: {}
-  url: https://repo.prefix.dev/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  url: https://repo.prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
   hash:
-    md5: 6797b005cd0f439c4c5c9ac565783700
-    sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+    md5: 71b24316859acd00bdb8b38f5e2ce328
+    sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
   category: main
   optional: false
 - name: vc
@@ -2588,7 +2588,7 @@ package:
   category: main
   optional: false
 - name: geoh5py
-  version: 0.12.0a2.dev42+ae647668
+  version: 0.12.0a2.dev60+3a91dd92
   manager: pip
   platform: linux-64
   dependencies:
@@ -2596,16 +2596,16 @@ package:
     numpy: '>=1.26.0,<1.27.0'
     pillow: '>=10.3.0,<10.4.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
   hash:
-    sha256: ae6476684d48892a7ce863c1165b8f6f488a3867
+    sha256: 3a91dd92144a34b3c1ad1e5885029a7102e6337c
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
   category: main
   optional: false
 - name: geoh5py
-  version: 0.12.0a2.dev42+ae647668
+  version: 0.12.0a2.dev60+3a91dd92
   manager: pip
   platform: win-64
   dependencies:
@@ -2613,11 +2613,11 @@ package:
     numpy: '>=1.26.0,<1.27.0'
     pillow: '>=10.3.0,<10.4.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
   hash:
-    sha256: ae6476684d48892a7ce863c1165b8f6f488a3867
+    sha256: 3a91dd92144a34b3c1ad1e5885029a7102e6337c
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
   category: main
   optional: false

--- a/py-3.12.conda-lock.yml
+++ b/py-3.12.conda-lock.yml
@@ -99,10 +99,10 @@ package:
   dependencies:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://repo.prefix.dev/conda-forge/linux-64/astroid-3.3.11-py312h7900ff3_0.conda
+  url: https://repo.prefix.dev/conda-forge/linux-64/astroid-3.3.11-py312h7900ff3_1.conda
   hash:
-    md5: 2c4719e9d1416a9070de683d0e44a12f
-    sha256: 543e3ad753b987efd3ad5e17c3f55aaf6b2fed5699bf4696f38a172845634e0e
+    md5: f68064e559452bab9180c8f90392d724
+    sha256: e8ddf4c3e00cbf6350ab2f9a046b04c6b5df71fa111e5f172bce3723b0ab6ac1
   category: dev
   optional: true
 - name: astroid
@@ -112,10 +112,10 @@ package:
   dependencies:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://repo.prefix.dev/conda-forge/win-64/astroid-3.3.11-py312h2e8e312_0.conda
+  url: https://repo.prefix.dev/conda-forge/win-64/astroid-3.3.11-py312h2e8e312_1.conda
   hash:
-    md5: 9958694a21711e5159ebd5323115a2a3
-    sha256: a66bf91868f27ea145f42536b090689ebb658cfa46d5c0ba0ba836978a08aef2
+    md5: 1f2355e2dae4d1cdfb625fbd4af95576
+    sha256: 67bc3573865fa08809779fc94def9f8de220553507cc700e546a7ee952472e94
   category: dev
   optional: true
 - name: bzip2
@@ -255,7 +255,7 @@ package:
   category: dev
   optional: true
 - name: coverage
-  version: 7.10.5
+  version: 7.10.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -264,14 +264,14 @@ package:
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     tomli: ''
-  url: https://repo.prefix.dev/conda-forge/linux-64/coverage-7.10.5-py312h8a5da7c_0.conda
+  url: https://repo.prefix.dev/conda-forge/linux-64/coverage-7.10.6-py312h8a5da7c_0.conda
   hash:
-    md5: 1534a930a40c7547dfcf477884c210d7
-    sha256: 163996c0940ee58e605722ab08d47746cb6618a92c35287ad574cc3b7b20d928
+    md5: 388d3fcdd451c6f9f31c00067826ce2e
+    sha256: 90686783b8afd9fd88283bc03b2cce114511ff6074b0d3c60ce7aabb67db8dc5
   category: dev
   optional: true
 - name: coverage
-  version: 7.10.5
+  version: 7.10.6
   manager: conda
   platform: win-64
   dependencies:
@@ -281,10 +281,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://repo.prefix.dev/conda-forge/win-64/coverage-7.10.5-py312h05f76fc_0.conda
+  url: https://repo.prefix.dev/conda-forge/win-64/coverage-7.10.6-py312h05f76fc_0.conda
   hash:
-    md5: b5df85abc3dd7cb713eecb7f49396e96
-    sha256: 40526b427d6425558d6c9c71cdd6f009214322b96aa443fc9672947e15886f9e
+    md5: 9fb90caf8b5e9b9b359ab75e7ef9abcf
+    sha256: f1002a5ded5ed2af022e98eae308929beb2fdcda18ef22f1014288b581a94c10
   category: dev
   optional: true
 - name: dill
@@ -371,14 +371,14 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     cached-property: ''
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    libgcc: '>=13'
-    numpy: '>=1.21,<3'
+    libgcc: '>=14'
+    numpy: '>=1.23,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://repo.prefix.dev/conda-forge/linux-64/h5py-3.14.0-nompi_py312h3faca00_100.conda
+  url: https://repo.prefix.dev/conda-forge/linux-64/h5py-3.14.0-nompi_py312ha4f8f14_101.conda
   hash:
-    md5: 2e1c2a9e706c74c4dd6f990a680f3f90
-    sha256: 9d23b72ee1138e14d379bb4c415cfdfc6944824e1844ff16ebf44e0defd1eddc
+    md5: fff67e7204b34a6e82ccf076786d1a7a
+    sha256: 6736b00b257aecef97e5e607ff275780cacdec48ff85963fe53abeb9ee4fb53f
   category: main
   optional: false
 - name: h5py
@@ -388,16 +388,16 @@ package:
   dependencies:
     cached-property: ''
     hdf5: '>=1.14.6,<1.14.7.0a0'
-    numpy: '>=1.21,<3'
+    numpy: '>=1.23,<3'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://repo.prefix.dev/conda-forge/win-64/h5py-3.14.0-nompi_py312h6cc2a29_100.conda
+    vc: '>=14.3,<15'
+    vc14_runtime: '>=14.44.35208'
+  url: https://repo.prefix.dev/conda-forge/win-64/h5py-3.14.0-nompi_py312h03cd2ba_101.conda
   hash:
-    md5: 7505235f79c9deb9e69fba7cca1a7c97
-    sha256: 836d84ebf958e74a154406e785b32c973eaad12163f1b7dae2c0448626acea9c
+    md5: dc73d015d4d8afbe3a5caf38e7be048a
+    sha256: 932f5a81723869cd4b201bbbac58f63c8e042ab6bb0afccc24a77e81f3eb40eb
   category: main
   optional: false
 - name: hdf5
@@ -1097,21 +1097,21 @@ package:
   category: main
   optional: false
 - name: libnghttp2
-  version: 1.64.0
+  version: 1.67.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.32.3,<2.0a0'
+    c-ares: '>=1.34.5,<2.0a0'
     libev: '>=4.33,<5.0a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
     libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.3.2,<4.0a0'
-  url: https://repo.prefix.dev/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+    openssl: '>=3.5.2,<4.0a0'
+  url: https://repo.prefix.dev/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
   hash:
-    md5: 19e57602824042dfd0446292ef90488b
-    sha256: b0f2b3695b13a989f75d8fd7f4778e1c7aabe3b36db83f0fe80b2cd812c0e975
+    md5: b499ce4b026493a13774bcf0f4c33849
+    sha256: a4a7dab8db4dc81c736e9a9b42bdfd97b087816e029e221380511960ac46c690
   category: main
   optional: false
 - name: libnsl
@@ -2405,14 +2405,14 @@ package:
   category: main
   optional: false
 - name: ucrt
-  version: 10.0.22621.0
+  version: 10.0.26100.0
   manager: conda
   platform: win-64
   dependencies: {}
-  url: https://repo.prefix.dev/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
+  url: https://repo.prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
   hash:
-    md5: 6797b005cd0f439c4c5c9ac565783700
-    sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
+    md5: 71b24316859acd00bdb8b38f5e2ce328
+    sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
   category: main
   optional: false
 - name: vc
@@ -2588,7 +2588,7 @@ package:
   category: main
   optional: false
 - name: geoh5py
-  version: 0.12.0a2.dev42+ae647668
+  version: 0.12.0a2.dev60+3a91dd92
   manager: pip
   platform: linux-64
   dependencies:
@@ -2596,16 +2596,16 @@ package:
     numpy: '>=1.26.0,<1.27.0'
     pillow: '>=10.3.0,<10.4.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
   hash:
-    sha256: ae6476684d48892a7ce863c1165b8f6f488a3867
+    sha256: 3a91dd92144a34b3c1ad1e5885029a7102e6337c
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
   category: main
   optional: false
 - name: geoh5py
-  version: 0.12.0a2.dev42+ae647668
+  version: 0.12.0a2.dev60+3a91dd92
   manager: pip
   platform: win-64
   dependencies:
@@ -2613,11 +2613,11 @@ package:
     numpy: '>=1.26.0,<1.27.0'
     pillow: '>=10.3.0,<10.4.0'
     pydantic: '>=2.5.2,<3.0.0'
-  url: git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+  url: git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
   hash:
-    sha256: ae6476684d48892a7ce863c1165b8f6f488a3867
+    sha256: 3a91dd92144a34b3c1ad1e5885029a7102e6337c
   source:
     type: url
-    url: git+https://github.com/MiraGeoscience/geoh5py.git@ae6476684d48892a7ce863c1165b8f6f488a3867
+    url: git+https://github.com/MiraGeoscience/geoh5py.git@3a91dd92144a34b3c1ad1e5885029a7102e6337c
   category: main
   optional: false


### PR DESCRIPTION
**DEVOPS-693 - migrate from conda-lock to pixi**
just to see if geoapps-utils can still build on latest geoh5py git revision