### PR TITLE
DEVOPS-977: use v3 of zizmor github workflows

### DIFF
--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -40,4 +40,4 @@ jobs:
       checks: write
       contents: read
       actions: read
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-zizmor-annotate.yml@v2
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-zizmor-annotate.yml@v3


### PR DESCRIPTION
**DEVOPS-977 - Zizmor: Allow trusted tag-pinned github actions**
