### PR TITLE
GEOPY-2744: Migrate core utilities to geoapps-utils and geoh5py

### DIFF
--- a/geoapps_utils/base.py
+++ b/geoapps_utils/base.py
@@ -167,7 +167,7 @@ class Driver(ABC):
             )
 
     @classmethod
-    def get_default_ui_json(cls) -> Path | None:
+    def get_default_ui_json_path(cls) -> Path | None:
         """
         Get the default ui.json file path for the application.
 
@@ -178,15 +178,16 @@ class Driver(ABC):
         return None
 
     @classmethod
-    def get_empty_ui_json(cls) -> BaseUIJson:
+    def get_default_ui_json(cls) -> BaseUIJson:
         """
-        Get an empty ui.json dictionary for the application.
+        Load the driver's default ui.json template from disk
+        with no parameters filled in.
 
-        :return: Empty ui.json dictionary.
+        :return: The default ui.json configuration.
         """
-        ui_json_path = cls.get_default_ui_json()
+        ui_json_path = cls.get_default_ui_json_path()
 
-        if ui_json_path is None:
+        if ui_json_path is None or not ui_json_path.exists():
             raise ValueError(f"Driver {cls} does not have a default ui.json.")
 
         ui_json = BaseUIJson.read(ui_json_path)

--- a/geoapps_utils/base.py
+++ b/geoapps_utils/base.py
@@ -21,7 +21,7 @@ from geoh5py import Workspace
 from geoh5py.groups import UIJsonGroup
 from geoh5py.objects import ObjectBase
 from geoh5py.shared.utils import stringify
-from geoh5py.ui_json import InputFile, monitored_directory_copy, BaseUIJson
+from geoh5py.ui_json import BaseUIJson, InputFile, monitored_directory_copy
 from geoh5py.ui_json.utils import fetch_active_workspace
 from pydantic import BaseModel, ConfigDict, ValidationError
 

--- a/geoapps_utils/base.py
+++ b/geoapps_utils/base.py
@@ -21,7 +21,7 @@ from geoh5py import Workspace
 from geoh5py.groups import UIJsonGroup
 from geoh5py.objects import ObjectBase
 from geoh5py.shared.utils import stringify
-from geoh5py.ui_json import InputFile, monitored_directory_copy
+from geoh5py.ui_json import InputFile, monitored_directory_copy, BaseUIJson
 from geoh5py.ui_json.utils import fetch_active_workspace
 from pydantic import BaseModel, ConfigDict, ValidationError
 
@@ -107,7 +107,6 @@ class Driver(ABC):
         :param filepath: Path to valid ui.json file for the application driver.
         :param kwargs: Additional keyword arguments for InputFile read_ui_json.
         """
-
         ifile = (
             cls.read_ui_json(filepath, **kwargs)
             if isinstance(filepath, str | Path)
@@ -177,6 +176,21 @@ class Driver(ABC):
         if issubclass(cls._params_class, Options):
             return cls._params_class.default_ui_json
         return None
+
+    @classmethod
+    def get_empty_ui_json(cls) -> BaseUIJson:
+        """
+        Get an empty ui.json dictionary for the application.
+
+        :return: Empty ui.json dictionary.
+        """
+        ui_json_path = cls.get_default_ui_json()
+
+        if ui_json_path is None:
+            raise ValueError(f"Driver {cls} does not have a default ui.json.")
+
+        ui_json = BaseUIJson.read(ui_json_path)
+        return ui_json
 
 
 class Options(BaseModel):
@@ -264,7 +278,6 @@ class Options(BaseModel):
 
         data.update(kwargs)
         options = cls.collect_input_from_dict(cls, data)  # type: ignore
-
         try:
             out = cls(**options)
         except ValidationError as errors:

--- a/tests/driver_test.py
+++ b/tests/driver_test.py
@@ -143,7 +143,7 @@ def test_base_options(tmp_path):
 
 def test_get_empty_ui_json():
     # Driver with BaseParams has no default ui.json path
-    with pytest.raises(ValueError, match="does not have a default ui.json"):
+    with pytest.raises(ValueError, match="does not have a default"):
         TestParamsDriver.get_empty_ui_json()
 
     # Driver with Options subclass that has a default_ui_json returns a BaseUIJson

--- a/tests/driver_test.py
+++ b/tests/driver_test.py
@@ -20,7 +20,7 @@ import pytest
 from geoh5py import Workspace
 from geoh5py.groups import UIJsonGroup
 from geoh5py.objects import Points
-from geoh5py.ui_json import InputFile, BaseUIJson
+from geoh5py.ui_json import BaseUIJson, InputFile
 from geoh5py.ui_json.templates import group_parameter, object_parameter
 
 from geoapps_utils.base import Options, get_logger

--- a/tests/driver_test.py
+++ b/tests/driver_test.py
@@ -20,7 +20,7 @@ import pytest
 from geoh5py import Workspace
 from geoh5py.groups import UIJsonGroup
 from geoh5py.objects import Points
-from geoh5py.ui_json import InputFile
+from geoh5py.ui_json import InputFile, BaseUIJson
 from geoh5py.ui_json.templates import group_parameter, object_parameter
 
 from geoapps_utils.base import Options, get_logger
@@ -139,6 +139,16 @@ def test_base_options(tmp_path):
 
     json_dict = json.loads(file_data.file_bytes.decode())
     assert json_dict.get("client", None) == "{" + str(pts.uid) + "}"
+
+
+def test_get_empty_ui_json():
+    # Driver with BaseParams has no default ui.json path
+    with pytest.raises(ValueError, match="does not have a default ui.json"):
+        TestParamsDriver.get_empty_ui_json()
+
+    # Driver with Options subclass that has a default_ui_json returns a BaseUIJson
+    ui_json = TestOptionsDriver.get_empty_ui_json()
+    assert isinstance(ui_json, BaseUIJson)
 
 
 def test_params_errors():

--- a/tests/driver_test.py
+++ b/tests/driver_test.py
@@ -66,7 +66,7 @@ def test_base_driver(tmp_path):
 
     driver = TestParamsDriver(params)
 
-    assert TestParamsDriver.get_default_ui_json() is None
+    assert TestParamsDriver.get_default_ui_json_path() is None
 
     driver.start(tmp_path / "test_ifile.ui.json")
 
@@ -120,7 +120,7 @@ def test_base_options(tmp_path):
 
     driver = TestOptionsDriver(options)
 
-    assert TestOptionsDriver.get_default_ui_json().exists()  # type: ignore
+    assert TestOptionsDriver.get_default_ui_json_path().exists()  # type: ignore
 
     assert isinstance(driver.params, TestOptions)
     assert driver.params_class == TestOptions
@@ -144,10 +144,10 @@ def test_base_options(tmp_path):
 def test_get_empty_ui_json():
     # Driver with BaseParams has no default ui.json path
     with pytest.raises(ValueError, match="does not have a default"):
-        TestParamsDriver.get_empty_ui_json()
+        TestParamsDriver.get_default_ui_json()
 
     # Driver with Options subclass that has a default_ui_json returns a BaseUIJson
-    ui_json = TestOptionsDriver.get_empty_ui_json()
+    ui_json = TestOptionsDriver.get_default_ui_json()
     assert isinstance(ui_json, BaseUIJson)
 
 


### PR DESCRIPTION
**GEOPY-2744 - Migrate core utilities to geoapps-utils and geoh5py**
move functions from geopy-qa to geoapps-utils