### PR TITLE
DEVOPS-1033: Rename JIRA secrets to their _WRITE counterparts

### DIFF
--- a/.github/workflows/issue_to_jira.yml
+++ b/.github/workflows/issue_to_jira.yml
@@ -17,5 +17,5 @@ jobs:
       components: '[{"name": "geoapps"}]'
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN_WRITE }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL_WRITE }}


### PR DESCRIPTION
**DEVOPS-1033 - secured access from GitHub to JIRA**
DEVOPS-1033: rename the JIRA secrets used by the reusable `MiraGeoscience/CI-tools/.github/workflows/reusable-jira-issue_to_jira.yml@` workflow's caller:
- `JIRA_USER_EMAIL` -> `JIRA_USER_EMAIL_WRITE`
- `JIRA_API_TOKEN` -> `JIRA_API_TOKEN_WRITE`

This PR was run by a PowerShell script with the help of Copilot.